### PR TITLE
[Frontend] 학생 대시보드 및 성적 조회 화면 (#26)

### DIFF
--- a/frontend/src/pages/student/StudentCoursePage.jsx
+++ b/frontend/src/pages/student/StudentCoursePage.jsx
@@ -1,0 +1,94 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+import useAuthStore from '../../store/authStore'
+import { api } from '../../utils/api'
+
+const GRADE_COLORS = {
+  'A+': 'bg-green-100 text-green-700',
+  'A0': 'bg-green-100 text-green-600',
+  'B+': 'bg-blue-100 text-blue-700',
+  'B0': 'bg-blue-100 text-blue-600',
+  'C+': 'bg-yellow-100 text-yellow-700',
+  'C0': 'bg-yellow-100 text-yellow-600',
+  'D+': 'bg-orange-100 text-orange-700',
+  'D0': 'bg-orange-100 text-orange-600',
+  'F':  'bg-red-100 text-red-600',
+}
+
+export default function StudentCoursePage() {
+  const { token } = useAuthStore()
+  const navigate = useNavigate()
+  const [grouped, setGrouped] = useState(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    api.get('/api/v1/student/courses', { token })
+      .then(setGrouped)
+      .catch(() => setError('수강 과목을 불러오지 못했습니다.'))
+  }, [token])
+
+  if (error) return <div className="card text-center py-12 text-red-500">{error}</div>
+  if (!grouped) return <div className="card text-center py-12 text-slate-400">불러오는 중...</div>
+
+  const semesters = Object.keys(grouped).sort().reverse()
+
+  if (semesters.length === 0) {
+    return (
+      <div className="card text-center py-16 text-slate-400">
+        <div className="text-4xl mb-3">📚</div>
+        <p>수강 중인 과목이 없습니다.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <h2 className="text-2xl font-bold text-slate-800">내 수강 과목</h2>
+
+      {semesters.map((sem) => (
+        <section key={sem}>
+          <h3 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">
+            {sem}
+          </h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {grouped[sem].map((course) => {
+              const gradeColor = course.grade ? (GRADE_COLORS[course.grade] || 'bg-slate-100 text-slate-600') : ''
+              return (
+                <div
+                  key={course.id}
+                  className="card cursor-pointer hover:shadow-lg transition-shadow"
+                  onClick={() => navigate(`/student/courses/${course.id}`)}
+                >
+                  <div className="flex justify-between items-start">
+                    <div>
+                      <h4 className="font-semibold text-slate-800">{course.course_name}</h4>
+                      <p className="text-sm text-slate-500 mt-0.5">
+                        {course.course_code}
+                        {course.section ? ` — ${course.section}분반` : ''}
+                      </p>
+                    </div>
+                    {course.grade ? (
+                      <span className={`px-2.5 py-0.5 rounded-full text-sm font-bold ${gradeColor}`}>
+                        {course.grade}
+                      </span>
+                    ) : (
+                      <span className="px-2 py-0.5 rounded text-xs bg-slate-100 text-slate-400">미산출</span>
+                    )}
+                  </div>
+                  <div className="mt-4 flex items-center gap-2 text-sm text-slate-500">
+                    <span>총점</span>
+                    {course.total_score != null ? (
+                      <span className="font-semibold text-slate-700">{course.total_score}점</span>
+                    ) : (
+                      <span className="text-slate-300">—</span>
+                    )}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/pages/student/StudentDashboard.jsx
+++ b/frontend/src/pages/student/StudentDashboard.jsx
@@ -1,11 +1,36 @@
-// 학생 대시보드 (이슈 #26에서 상세 구현)
+import { Routes, Route, Navigate, useNavigate } from 'react-router-dom'
+import useAuthStore from '../../store/authStore'
+import StudentCoursePage from './StudentCoursePage'
+import StudentGradeDetailPage from './StudentGradeDetailPage'
+
 export default function StudentDashboard() {
+  const { clearAuth, user } = useAuthStore()
+  const navigate = useNavigate()
+
   return (
-    <div className="min-h-screen bg-slate-50 p-8">
-      <div className="max-w-5xl mx-auto">
-        <h1 className="text-2xl font-bold text-slate-800 mb-6">학생 대시보드</h1>
-        <p className="text-slate-500">이슈 #26에서 구현 예정</p>
-      </div>
+    <div className="min-h-screen bg-slate-50">
+      <header className="bg-white border-b border-slate-200 px-8 py-4 flex justify-between items-center">
+        <div>
+          <h1 className="text-lg font-bold text-slate-800">SmartGrader</h1>
+          {user?.login_id && (
+            <p className="text-xs text-slate-400">{user.login_id}</p>
+          )}
+        </div>
+        <button
+          className="btn-secondary text-sm"
+          onClick={() => { clearAuth(); navigate('/login') }}
+        >
+          로그아웃
+        </button>
+      </header>
+
+      <main className="p-8 max-w-4xl mx-auto">
+        <Routes>
+          <Route index element={<Navigate to="courses" replace />} />
+          <Route path="courses" element={<StudentCoursePage />} />
+          <Route path="courses/:courseId" element={<StudentGradeDetailPage />} />
+        </Routes>
+      </main>
     </div>
   )
 }

--- a/frontend/src/pages/student/StudentGradeDetailPage.jsx
+++ b/frontend/src/pages/student/StudentGradeDetailPage.jsx
@@ -1,0 +1,120 @@
+import { useState, useEffect } from 'react'
+import { useParams, useNavigate } from 'react-router-dom'
+import useAuthStore from '../../store/authStore'
+import { api } from '../../utils/api'
+
+const TYPE_LABELS = { general: '일반', attendance: '출석', attitude: '태도' }
+
+function ScoreBadge({ value, label }) {
+  if (value == null) {
+    return <span className="px-1.5 py-0.5 rounded text-xs bg-slate-100 text-slate-400">미산출</span>
+  }
+  return <span className="font-medium text-slate-700">{label ?? value}</span>
+}
+
+export default function StudentGradeDetailPage() {
+  const { courseId } = useParams()
+  const { token } = useAuthStore()
+  const navigate = useNavigate()
+
+  const [data, setData] = useState(null)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    api.get(`/api/v1/student/courses/${courseId}/scores`, { token })
+      .then(setData)
+      .catch((err) => setError(err.message || '성적을 불러오지 못했습니다.'))
+  }, [courseId, token])
+
+  if (error) return (
+    <div>
+      <button className="text-sm text-slate-500 hover:text-slate-700 mb-4"
+        onClick={() => navigate('/student/courses')}>← 과목 목록</button>
+      <div className="card text-center py-12 text-red-500">{error}</div>
+    </div>
+  )
+
+  if (!data) return <div className="card text-center py-12 text-slate-400">불러오는 중...</div>
+
+  const { items, total_score, grade } = data
+
+  return (
+    <div>
+      <button className="text-sm text-slate-500 hover:text-slate-700 mb-4"
+        onClick={() => navigate('/student/courses')}>
+        ← 과목 목록
+      </button>
+
+      {/* 총점·학점 요약 카드 */}
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <div className="card text-center">
+          <p className="text-xs text-slate-400 mb-1">총점</p>
+          {total_score != null ? (
+            <p className="text-3xl font-bold text-slate-800">{total_score}<span className="text-lg font-normal text-slate-400">점</span></p>
+          ) : (
+            <p className="text-slate-300 mt-2">미산출</p>
+          )}
+        </div>
+        <div className="card text-center">
+          <p className="text-xs text-slate-400 mb-1">학점</p>
+          {grade ? (
+            <p className="text-3xl font-bold text-blue-600">{grade}</p>
+          ) : (
+            <p className="text-slate-300 mt-2">미산출</p>
+          )}
+        </div>
+      </div>
+
+      {/* 항목별 성적 테이블 */}
+      <div className="card p-0 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 border-b border-slate-200">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">항목</th>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">유형</th>
+              <th className="text-left px-4 py-3 font-medium text-slate-600">그룹</th>
+              <th className="text-center px-4 py-3 font-medium text-slate-600">점수</th>
+              <th className="text-center px-4 py-3 font-medium text-slate-600">기여점수</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {items.length === 0 && (
+              <tr>
+                <td colSpan={5} className="px-4 py-8 text-center text-slate-400">
+                  성적 항목이 없습니다.
+                </td>
+              </tr>
+            )}
+            {items.map((item) => {
+              const isAttend = item.item_type === 'attendance'
+              const scoreVal = isAttend
+                ? (item.absence_count != null ? `결석 ${item.absence_count}회` : null)
+                : item.raw_score
+
+              return (
+                <tr key={item.id} className={item.group_id ? 'bg-blue-50/20' : ''}>
+                  <td className="px-4 py-3 font-medium text-slate-800">{item.name}</td>
+                  <td className="px-4 py-3 text-slate-500">{TYPE_LABELS[item.item_type] ?? item.item_type}</td>
+                  <td className="px-4 py-3 text-slate-400 text-xs">
+                    {item.group_name
+                      ? <span className="bg-blue-50 text-blue-600 px-1.5 py-0.5 rounded">{item.group_name}</span>
+                      : <span>—</span>}
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <ScoreBadge value={scoreVal} label={scoreVal} />
+                  </td>
+                  <td className="px-4 py-3 text-center">
+                    <ScoreBadge
+                      value={item.contribution}
+                      label={`${item.contribution}점`}
+                    />
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **`StudentDashboard.jsx`**: 헤더(학번 표시) + 중첩 Routes (`courses`, `courses/:courseId`)
- **`StudentCoursePage.jsx`**:
  - 학기별로 그룹화된 수강 과목 카드 목록 (최신 학기 순)
  - 학점 색상 배지 (A+=초록/B+=파랑/C+=노랑/D+=주황/F=빨강)
  - 총점·학점 미산출 시 "미산출" 배지 표시
- **`StudentGradeDetailPage.jsx`**:
  - 총점·학점 요약 카드 2개 (미산출 시 "미산출" 표시)
  - 항목별 테이블: 유형/그룹/점수/기여점수
  - 출석 항목: "결석 N회" 형식
  - 그룹 소속 항목: 그룹명 파란색 배지 + 배경 구분
  - 기여점수 null → "미산출" 배지 (총점 미계산 상태)

Closes #26

## Test plan

- [x] 학기별 그룹화 과목 목록 표시 (`Object.keys(grouped).sort().reverse()`)
- [x] 과목 카드 클릭 → `/student/courses/:id` 상세 이동
- [x] 총점·학점 미산출 → "미산출" 배지 (`value == null`)
- [x] 항목별 점수·기여점수 표시 (`ScoreBadge` 컴포넌트)
- [x] 다른 학생 데이터 불가 (백엔드 RLS + `require_role("student")` + `student_id=current_user.id`)
- [x] `npm run build` 통과 (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)